### PR TITLE
Improve SAT Implementations in Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ permissions:
   contents: read
 jobs:
   ash-ci:
-    strategy:
-      matrix:
-        sat_solver: ["SimpleSat", "Picosat"]
     uses: ash-project/ash/.github/workflows/ash-ci.yml@main
     secrets:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
@@ -27,8 +24,8 @@ jobs:
       id-token: write
       security-events: write
     with:
-      release: ${{matrix.sat_solver == 'Picosat'}}
-      publish-docs: ${{matrix.sat_solver == 'Picosat'}}
+      release: true
+      publish-docs: true
       spark-formatter: false
       codegen: false
       doctor: true
@@ -37,6 +34,5 @@ jobs:
       sobelow: true
       postgres: false
       tenants: false
-      sat-solver: ${{ matrix.sat_solver }}
       reuse: true
       community-files: true

--- a/lib/crux/implementation.ex
+++ b/lib/crux/implementation.ex
@@ -29,7 +29,10 @@ cond do
 
       @doc false
       def solve_expression(cnf) do
-        Module.concat([System.get_env("SAT_SOLVER") || "Picosat"]).solve(cnf)
+        env_solver = Module.concat([System.get_env("SAT_SOLVER") || "Picosat"])
+        solver = Process.get(__MODULE__, env_solver)
+
+        solver.solve(cnf)
       end
 
       @doc check_doc

--- a/test/crux_test.exs
+++ b/test/crux_test.exs
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: MIT
 
 defmodule CruxTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case,
+    async: false,
+    parameterize: [%{solver: Picosat}, %{solver: SimpleSat}]
+
   use ExUnitProperties
 
   import Crux.Expression, only: [b: 1]
@@ -12,6 +15,11 @@ defmodule CruxTest do
   alias Crux.Formula
 
   doctest Crux
+
+  setup %{solver: solver} do
+    Process.put(Crux.Implementation, solver)
+    :ok
+  end
 
   describe inspect(&Crux.solve/1) do
     test "finds a satisfying assignment for a satisfiable formula" do


### PR DESCRIPTION
# Changes

* Allow to switch SAT Implementation at runtime if `:sat_testing` is enabled via Process dict
* Only run CI suite once
* Parameterized Tests for Modules using solver to both simple_sat and picosat

This will fail until https://github.com/ash-project/simple_sat/pull/10 is merged.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
