### PR TITLE
Remove CommutativityLaw in Simplify

### DIFF
--- a/lib/crux/expression.ex
+++ b/lib/crux/expression.ex
@@ -597,7 +597,6 @@ defmodule Crux.Expression do
         RewriteRule.AssociativityLaw,
         RewriteRule.DistributivityBasedSimplificationLaw,
         RewriteRule.ComplementLaw,
-        RewriteRule.CommutativityLaw,
         RewriteRule.TautologyLaw,
         RewriteRule.ConsensusTheorem,
         RewriteRule.UnitResolution
@@ -827,7 +826,6 @@ defmodule Crux.Expression do
     |> RewriteRule.AssociativityLaw.walk()
     |> RewriteRule.DistributivityBasedSimplificationLaw.walk()
     |> RewriteRule.ComplementLaw.walk()
-    |> RewriteRule.CommutativityLaw.walk()
     |> RewriteRule.TautologyLaw.walk()
     |> RewriteRule.ConsensusTheorem.walk()
     |> RewriteRule.UnitResolution.walk()
@@ -845,8 +843,8 @@ defmodule Crux.Expression do
 
       iex> # User roles - person can have at most one role
       ...> at_most_one([:admin, :user, :guest])
-      {:and, {:not, {:and, :guest, :user}},
-       {:and, {:not, {:and, :admin, :guest}}, {:not, {:and, :admin, :user}}}}
+      {:and, {:and, {:not, {:and, :admin, :user}}, {:not, {:and, :admin, :guest}}},
+       {:not, {:and, :guest, :user}}}
 
       iex> # Payment methods - choose at most one option
       ...> at_most_one([:credit_card, :paypal])
@@ -896,13 +894,13 @@ defmodule Crux.Expression do
       iex> # Database transaction - both happen or neither
       ...> all_or_none([:begin_transaction, :commit_transaction])
       {:not,
-       {:and, {:not, {:and, :begin_transaction, :commit_transaction}},
-        {:or, :begin_transaction, :commit_transaction}}}
+       {:and, {:or, :begin_transaction, :commit_transaction},
+        {:not, {:and, :begin_transaction, :commit_transaction}}}}
 
       iex> # Feature flags - UI and API dark mode go together
       ...> all_or_none([:dark_mode_ui, :dark_mode_api])
       {:not,
-       {:and, {:not, {:and, :dark_mode_api, :dark_mode_ui}}, {:or, :dark_mode_api, :dark_mode_ui}}}
+       {:and, {:or, :dark_mode_api, :dark_mode_ui}, {:not, {:and, :dark_mode_api, :dark_mode_ui}}}}
 
       iex> # Empty list always satisfied
       ...> all_or_none([])
@@ -951,7 +949,7 @@ defmodule Crux.Expression do
 
       iex> # User preference - must pick exactly one theme
       ...> exactly_one([:light_theme, :dark_theme])
-      {:and, {:not, {:and, :dark_theme, :light_theme}}, {:or, :dark_theme, :light_theme}}
+      {:and, {:or, :light_theme, :dark_theme}, {:not, {:and, :light_theme, :dark_theme}}}
 
       iex> # Empty list can never satisfy exactly one
       ...> exactly_one([])

--- a/lib/crux/expression/rewrite_rule/absorption_law.ex
+++ b/lib/crux/expression/rewrite_rule/absorption_law.ex
@@ -24,8 +24,16 @@ defmodule Crux.Expression.RewriteRule.AbsorptionLaw do
 
   @impl Crux.Expression.RewriteRule
   def walk(b(expr and (expr or _other))), do: expr
+  def walk(b(expr and (_other or expr))), do: expr
+
   def walk(b((expr or _other) and expr)), do: expr
+  def walk(b((_other or expr) and expr)), do: expr
+
   def walk(b(expr or (expr and _other))), do: expr
+  def walk(b(expr or (_other and expr))), do: expr
+
   def walk(b((expr and _other) or expr)), do: expr
+  def walk(b((_other and expr) or expr)), do: expr
+
   def walk(other), do: other
 end

--- a/lib/crux/expression/rewrite_rule/associativity_law.ex
+++ b/lib/crux/expression/rewrite_rule/associativity_law.ex
@@ -25,8 +25,16 @@ defmodule Crux.Expression.RewriteRule.AssociativityLaw do
 
   @impl Crux.Expression.RewriteRule
   def walk(b(expr or (expr or other))), do: b(expr or other)
+  def walk(b(expr or (other or expr))), do: b(expr or other)
+
   def walk(b(expr or other or expr)), do: b(expr or other)
+  def walk(b(other or expr or expr)), do: b(expr or other)
+
   def walk(b(expr and (expr and other))), do: b(expr and other)
+  def walk(b(expr and (other and expr))), do: b(expr and other)
+
   def walk(b(expr and other and expr)), do: b(expr and other)
+  def walk(b(other and expr and expr)), do: b(expr and other)
+
   def walk(other), do: other
 end

--- a/lib/crux/expression/rewrite_rule/complement_law.ex
+++ b/lib/crux/expression/rewrite_rule/complement_law.ex
@@ -30,7 +30,12 @@ defmodule Crux.Expression.RewriteRule.ComplementLaw do
   def walk(b(not expr or expr)), do: true
   def walk(b(expr and not expr)), do: false
   def walk(b(not expr and expr)), do: false
+
   def walk(b((expr and left) or (expr and not left))), do: expr
+  def walk(b((left and expr) or (not left and expr))), do: expr
+
   def walk(b((expr or left) and (expr or not left))), do: expr
+  def walk(b((left or expr) and (not left or expr))), do: expr
+
   def walk(other), do: other
 end

--- a/test/crux/expression_test.exs
+++ b/test/crux/expression_test.exs
@@ -607,7 +607,7 @@ defmodule Crux.ExpressionTest do
 
     test "creates xnor constraint for two variables" do
       result = Expression.all_or_none([:a, :b])
-      assert result == b(not (not (:a and :b) and (:a or :b)))
+      assert result == b(not ((:a or :b) and not (:a and :b)))
     end
 
     test "models feature flags correctly" do
@@ -636,7 +636,7 @@ defmodule Crux.ExpressionTest do
     test "creates constraints for exactly one of two variables" do
       result = Expression.exactly_one([:a, :b])
       # Should be: (at least one) AND (at most one)
-      assert result == b(not (:a and :b) and (:a or :b))
+      assert result == b((:a or :b) and not (:a and :b))
     end
 
     test "models order status correctly" do


### PR DESCRIPTION
Depending on the business domain, checks might be ordered a certain way to evaluate cheap variables before more expensive ones. This commit:
* Removes CommutativityLaw from simplify
* Implements some laws ordered backwards
* Fixes tests where CommutativityLaw changed the order

If you like the balancing of the CommutativityLaw, call both `balance` and `simplify` on the expression.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
