### PR TITLE
style: use consistent operators in De Morgan's Law

### DIFF
--- a/lib/crux/expression/rewrite_rule/de_morgans_law.ex
+++ b/lib/crux/expression/rewrite_rule/de_morgans_law.ex
@@ -26,7 +26,7 @@ defmodule Crux.Expression.RewriteRule.DeMorgansLaw do
   def needs_reapplication?, do: true
 
   @impl RewriteRule
-  def walk(b(nand(left, right))), do: b(not left or not right)
-  def walk(b(nor(left, right))), do: b(not left and not right)
+  def walk(b(not (left and right))), do: b(not left or not right)
+  def walk(b(not (left or right))), do: b(not left and not right)
   def walk(other), do: other
 end


### PR DESCRIPTION
Update De Morgan's Law to use basic operators (`not`, `and`, `or`) instead of `nand`/`nor`:

- `NOT (A AND B) = (NOT A) OR (NOT B)`
- `NOT (A OR B) = (NOT A) AND (NOT B)`

This matches the moduledoc and other rewrite rules which only use basic operators.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [X] Refactoring
- [ ] Update dependencies
