### PR TITLE
improvement: apply tseitin transformation to CNF conversion

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -50,7 +50,7 @@
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:
       #
-      strict: false,
+      strict: true,
       #
       # To modify the timeout for parsing files, change this value:
       #

--- a/lib/crux.ex
+++ b/lib/crux.ex
@@ -195,7 +195,7 @@ defmodule Crux do
 
   def satisfying_scenarios(formula, opts) do
     original_cnf = formula.cnf
-    negation_encoding = build_negation_encoding(original_cnf)
+    negation_encoding = build_negation_encoding(formula)
 
     formula
     |> enumerate_dimacs_scenarios(original_cnf, negation_encoding, [])
@@ -346,27 +346,41 @@ defmodule Crux do
   end
 
   # Builds an encoding for the negation of a CNF formula.
-  # Creates selector variables for each clause and gadget clauses that encode:
-  # "if selector_i is true, then clause_i is false"
-  # Used for implication testing via satisfiability checking.
-  @spec build_negation_encoding(Formula.cnf()) :: negation_encoding()
-  defp build_negation_encoding(cnf) do
+  # Creates selector variables for each "assertion" clause and gadget clauses
+  # that encode: "if selector_i is true, then assertion_i is false".
+  # Tseitin-encoded formulas include `definitions` — clauses that bind
+  # auxiliary variables to sub-expressions and must always hold (they are
+  # not part of the semantic content being implied). Those are appended
+  # verbatim so they remain required in implication queries.
+  @spec build_negation_encoding(Formula.t(variable)) :: negation_encoding()
+        when variable: term()
+  defp build_negation_encoding(%Formula{cnf: cnf, definitions: definitions}) do
+    assertions =
+      case definitions do
+        [] ->
+          cnf
+
+        _ ->
+          definition_set = MapSet.new(definitions)
+          Enum.reject(cnf, &MapSet.member?(definition_set, &1))
+      end
+
     variables = cnf |> List.flatten() |> Enum.map(&abs/1)
     max_variable_id = Enum.max([0 | variables])
-    clause_count = length(cnf)
+    clause_count = length(assertions)
 
     first_selector = max_variable_id + 1
     last_selector = max_variable_id + clause_count
     selector_vars = Enum.to_list(first_selector..last_selector//1)
 
     encoding_clauses =
-      cnf
+      assertions
       |> Enum.zip(selector_vars)
       |> Enum.flat_map(fn {clause, selector_var} ->
         Enum.map(clause, fn literal -> [-selector_var, -literal] end)
       end)
 
-    %{selectors: selector_vars, gadget_clauses: encoding_clauses}
+    %{selectors: selector_vars, gadget_clauses: encoding_clauses ++ definitions}
   end
 
   # Adds a blocking clause to prevent rediscovering the same minimal assignment.
@@ -385,9 +399,21 @@ defmodule Crux do
         }
         when variable: term()
   defp unbind_scenario(scenario, bindings) do
-    Map.new(scenario, fn
-      literal when literal > 0 -> {Map.fetch!(bindings, literal), true}
-      literal when literal < 0 -> {Map.fetch!(bindings, -literal), false}
+    # Tseitin-encoded formulas include auxiliary variable ids in the
+    # solver's model. Those ids are absent from `bindings`, so we silently
+    # drop them — only user-supplied variables appear in returned scenarios.
+    Enum.reduce(scenario, %{}, fn literal, acc ->
+      {id, value} =
+        if literal > 0 do
+          {literal, true}
+        else
+          {-literal, false}
+        end
+
+      case bindings do
+        %{^id => variable} -> Map.put(acc, variable, value)
+        _ -> acc
+      end
     end)
   end
 

--- a/lib/crux/formula.ex
+++ b/lib/crux/formula.ex
@@ -168,21 +168,7 @@ defmodule Crux.Formula do
         @simple_false
 
       expression ->
-        %{
-          cnf: cnf,
-          definitions: definitions,
-          bindings: bindings,
-          reverse_bindings: reverse_bindings,
-          auxiliaries: auxiliaries
-        } = Tseitin.transform(expression)
-
-        %__MODULE__{
-          cnf: cnf,
-          bindings: bindings,
-          reverse_bindings: reverse_bindings,
-          definitions: definitions,
-          auxiliaries: auxiliaries
-        }
+        Tseitin.transform(expression)
     end
   end
 

--- a/lib/crux/formula.ex
+++ b/lib/crux/formula.ex
@@ -388,5 +388,4 @@ defmodule Crux.Formula do
 
   defp literal_to_expression(literal, bindings) when literal < 0,
     do: b(not Map.fetch!(bindings, -literal))
-
 end

--- a/lib/crux/formula.ex
+++ b/lib/crux/formula.ex
@@ -19,7 +19,9 @@ defmodule Crux.Formula do
   @type t(variable) :: %__MODULE__{
           cnf: cnf(),
           bindings: bindings(variable),
-          reverse_bindings: reverse_bindings(variable)
+          reverse_bindings: reverse_bindings(variable),
+          definitions: definitions(),
+          auxiliaries: auxiliaries()
         }
 
   @typedoc """
@@ -76,46 +78,88 @@ defmodule Crux.Formula do
   """
   @type bindings() :: bindings(term())
 
-  @enforce_keys [:cnf, :bindings, :reverse_bindings]
-  defstruct [:cnf, :bindings, :reverse_bindings]
+  @typedoc """
+  Auxiliary definition clauses produced by Tseitin encoding.
 
-  @simple_true %{__struct__: __MODULE__, cnf: [], bindings: %{}, reverse_bindings: %{}}
+  These clauses bind each auxiliary variable to the truth value of the
+  sub-expression it represents. They are a subset of `cnf/0` and must
+  always hold; consumers performing implication tests must not negate
+  them.
+  """
+  @type definitions() :: [clause()]
+
+  @typedoc """
+  The set of variable ids introduced by Tseitin encoding.
+
+  Auxiliary ids appear in `cnf/0` but never in `bindings/1`.
+  """
+  @type auxiliaries() :: MapSet.t(pos_integer())
+
+  @enforce_keys [:cnf, :bindings, :reverse_bindings]
+  defstruct [
+    :cnf,
+    :bindings,
+    :reverse_bindings,
+    definitions: [],
+    auxiliaries: MapSet.new()
+  ]
+
+  @simple_true %{
+    __struct__: __MODULE__,
+    cnf: [],
+    bindings: %{},
+    reverse_bindings: %{},
+    definitions: [],
+    auxiliaries: MapSet.new()
+  }
   @simple_false %{
     __struct__: __MODULE__,
     cnf: [[1], [-1]],
     bindings: %{1 => false},
-    reverse_bindings: %{false => 1}
+    reverse_bindings: %{false => 1},
+    definitions: [],
+    auxiliaries: MapSet.new()
   }
 
   @doc """
   Converts a boolean expression to a SAT formula in Conjunctive Normal Form (CNF).
 
+  The CNF is produced via the Tseitin transformation: each compound
+  sub-expression gets a fresh auxiliary variable and a small set of
+  "definition" clauses that bind the auxiliary to the sub-expression's
+  truth value. The resulting CNF grows linearly with the size of the
+  input — the naive distributive-law approach can blow up
+  exponentially. Auxiliary variables never appear in `:bindings` or in
+  scenarios returned by `Crux.solve/1` and `Crux.satisfying_scenarios/2`.
+
+  `to_expression/1` reverses the encoding by substituting each auxiliary
+  with its definition and simplifying.
+
   ## Examples
 
       iex> import Crux.Expression
-      ...> expression = b(:a and :b)
-      ...> Formula.from_expression(expression)
-      %Formula{
-        cnf: [[1], [2]],
-        bindings: %{1 => :a, 2 => :b},
-        reverse_bindings: %{a: 1, b: 2}
-      }
+      ...> formula = Formula.from_expression(b(:a and :b))
+      ...> formula.bindings
+      %{1 => :a, 2 => :b}
+      iex> Formula.to_expression(formula)
+      b(:a and :b)
 
-      iex> expression = b(:x or not :y)
-      ...> Formula.from_expression(expression)
-      %Formula{
-        cnf: [[1, -2]],
-        bindings: %{1 => :x, 2 => :y},
-        reverse_bindings: %{x: 1, y: 2}
-      }
+      iex> import Crux.Expression
+      ...> formula = Formula.from_expression(b(:x or not :y))
+      ...> formula.bindings
+      %{1 => :x, 2 => :y}
+      iex> Formula.to_expression(formula)
+      b(:x or not :y)
 
   """
   @spec from_expression(Expression.t(variable)) :: t(variable) when variable: term()
   def from_expression(expression) do
-    expression
-    |> Expression.balance()
-    |> Expression.simplify()
-    |> case do
+    simplified =
+      expression
+      |> Expression.balance()
+      |> Expression.simplify()
+
+    case simplified do
       true ->
         @simple_true
 
@@ -123,15 +167,20 @@ defmodule Crux.Formula do
         @simple_false
 
       expression ->
-        {bindings, reverse_bindings, expression} =
-          expression
-          |> Expression.to_cnf()
-          |> extract_bindings()
+        %{
+          cnf: cnf,
+          definitions: definitions,
+          bindings: bindings,
+          reverse_bindings: reverse_bindings,
+          auxiliaries: auxiliaries
+        } = Crux.Formula.Tseitin.transform(expression)
 
         %__MODULE__{
-          cnf: expression |> lift_clauses() |> Enum.uniq(),
+          cnf: cnf,
           bindings: bindings,
-          reverse_bindings: reverse_bindings
+          reverse_bindings: reverse_bindings,
+          definitions: definitions,
+          auxiliaries: auxiliaries
         }
     end
   end
@@ -139,16 +188,22 @@ defmodule Crux.Formula do
   @doc """
   Converts a SAT formula back to a boolean expression.
 
+  For Tseitin-encoded formulas (the output of `from_expression/1`), this
+  substitutes each auxiliary variable with its definition and simplifies
+  — recovering an expression equivalent to the original source.
+
+  Formulas constructed manually with no auxiliaries are walked
+  clause-by-clause, mapping each literal back through `:bindings`.
+
   ## Examples
 
-      iex> formula = %Formula{
-      ...>   cnf: [[1], [2]],
-      ...>   bindings: %{1 => :a, 2 => :b},
-      ...>   reverse_bindings: %{a: 1, b: 2}
-      ...> }
-      ...>
-      ...> Formula.to_expression(formula)
+      iex> import Crux.Expression
+      ...> Formula.to_expression(Formula.from_expression(b(:a and :b)))
       b(:a and :b)
+
+      iex> import Crux.Expression
+      ...> Formula.to_expression(Formula.from_expression(b(:x or not :y)))
+      b(:x or not :y)
 
       iex> formula = %Formula{
       ...>   cnf: [[1, -2]],
@@ -160,15 +215,122 @@ defmodule Crux.Formula do
       b(:x or not :y)
 
   """
-  @spec to_expression(formula :: t(variable)) :: Expression.cnf(variable) when variable: term()
+  @spec to_expression(formula :: t(variable)) :: Expression.t(variable) when variable: term()
   def to_expression(formula)
   def to_expression(@simple_true), do: true
   def to_expression(@simple_false), do: false
 
-  def to_expression(%__MODULE__{cnf: cnf, bindings: bindings}) do
-    cnf
-    |> Enum.map(&clause_to_expression(&1, bindings))
-    |> Enum.reduce(&b(&2 and &1))
+  def to_expression(%__MODULE__{
+        cnf: cnf,
+        bindings: bindings,
+        definitions: definitions,
+        auxiliaries: auxiliaries
+      }) do
+    if MapSet.size(auxiliaries) == 0 do
+      # Plain CNF (e.g. hand-constructed) — walk the clauses directly.
+      cnf
+      |> Enum.map(&clause_to_expression(&1, bindings))
+      |> Enum.reduce(&b(&2 and &1))
+    else
+      definition_set = MapSet.new(definitions)
+      assertions = Enum.reject(cnf, &MapSet.member?(definition_set, &1))
+
+      aux_definitions = build_aux_definitions(definitions, auxiliaries)
+
+      assertions
+      |> Enum.map(&clause_to_expanded_expression(&1, aux_definitions, bindings))
+      |> Enum.reduce(&b(&2 and &1))
+      |> Expression.simplify()
+    end
+  end
+
+  # Recovers `aux_id => {:and | :or, [literal]}` from the Tseitin
+  # definition clauses. Tseitin produces three definition clauses per
+  # auxiliary; only the "long" clause (length ≥ 3) is needed — its
+  # polarity pattern tells us whether the auxiliary represents an AND
+  # (one positive literal, rest negative) or an OR (one negative
+  # literal, rest positive). Children are encoded before parents, so the
+  # auxiliary being defined is always the literal with the largest
+  # absolute id in the clause.
+  @spec build_aux_definitions(definitions(), auxiliaries()) :: %{
+          pos_integer() => {:and | :or, [literal()]}
+        }
+  defp build_aux_definitions(definitions, auxiliaries) do
+    definitions
+    |> Enum.filter(&(length(&1) >= 3))
+    |> Enum.flat_map(fn clause ->
+      max_lit =
+        Enum.max_by(clause, &abs/1)
+
+      aux_id = abs(max_lit)
+
+      if MapSet.member?(auxiliaries, aux_id) do
+        others = Enum.reject(clause, &(abs(&1) == aux_id))
+
+        definition =
+          if max_lit > 0 do
+            # AND: long clause is (¬op_1 ∨ ¬op_2 ∨ aux); operands are
+            # the literals' negations.
+            {:and, Enum.map(others, &(-&1))}
+          else
+            # OR: long clause is (¬aux ∨ op_1 ∨ op_2); operands appear
+            # with their natural polarity.
+            {:or, others}
+          end
+
+        [{aux_id, definition}]
+      else
+        []
+      end
+    end)
+    |> Map.new()
+  end
+
+  @spec clause_to_expanded_expression(
+          clause(),
+          %{pos_integer() => {:and | :or, [literal()]}},
+          bindings(variable)
+        ) :: Expression.t(variable)
+        when variable: term()
+  defp clause_to_expanded_expression(clause, aux_definitions, bindings) do
+    clause
+    |> Enum.map(&literal_to_expanded_expression(&1, aux_definitions, bindings))
+    |> Enum.reduce(&b(&2 or &1))
+  end
+
+  @spec literal_to_expanded_expression(
+          literal(),
+          %{pos_integer() => {:and | :or, [literal()]}},
+          bindings(variable)
+        ) :: Expression.t(variable)
+        when variable: term()
+  defp literal_to_expanded_expression(literal, aux_definitions, bindings) when literal > 0,
+    do: resolve_id(literal, aux_definitions, bindings)
+
+  defp literal_to_expanded_expression(literal, aux_definitions, bindings) when literal < 0,
+    do: b(not resolve_id(-literal, aux_definitions, bindings))
+
+  @spec resolve_id(
+          pos_integer(),
+          %{pos_integer() => {:and | :or, [literal()]}},
+          bindings(variable)
+        ) :: Expression.t(variable)
+        when variable: term()
+  defp resolve_id(id, aux_definitions, bindings) do
+    case Map.fetch(aux_definitions, id) do
+      {:ok, {:and, operands}} ->
+        operands
+        |> Enum.map(&literal_to_expanded_expression(&1, aux_definitions, bindings))
+        |> Enum.reduce(&b(&2 and &1))
+
+      {:ok, {:or, operands}} ->
+        operands
+        |> Enum.map(&literal_to_expanded_expression(&1, aux_definitions, bindings))
+        |> Enum.reduce(&b(&2 or &1))
+
+      :error ->
+        Map.fetch!(bindings, id)
+    end
   end
 
   @doc """
@@ -177,17 +339,20 @@ defmodule Crux.Formula do
   Takes a formula struct and returns a string in the DIMACS CNF format
   that can be consumed by SAT solvers like PicoSAT.
 
+  The header reports the highest variable id used in the CNF, which
+  includes Tseitin auxiliary variables.
+
   ## Examples
 
       iex> alias Crux.{Expression, Formula}
-      ...> formula = Formula.from_expression(Expression.b(:a and :b))
+      ...> formula = Formula.from_expression(Expression.b(:a))
       ...> Formula.to_picosat(formula)
-      "p cnf 2 2\\n1 0\\n2 0"
+      "p cnf 1 1\\n1 0"
 
   """
   @spec to_picosat(t()) :: String.t()
-  def to_picosat(%__MODULE__{cnf: clauses, bindings: bindings}) do
-    variable_count = map_size(bindings)
+  def to_picosat(%__MODULE__{cnf: clauses, bindings: bindings, auxiliaries: auxiliaries}) do
+    variable_count = map_size(bindings) + MapSet.size(auxiliaries)
     clause_count = length(clauses)
 
     formatted_input =
@@ -224,52 +389,4 @@ defmodule Crux.Formula do
   defp literal_to_expression(literal, bindings) when literal < 0,
     do: b(not Map.fetch!(bindings, -literal))
 
-  @spec extract_bindings(expression :: Expression.t(variable)) ::
-          {bindings(variable), reverse_bindings(variable), Expression.t(literal())}
-        when variable: term()
-  defp extract_bindings(expression) do
-    {expression, bindings} = Expression.postwalk(expression, %{current: 1}, &bind_variable/2)
-
-    reverse_bindings = Map.delete(bindings, :current)
-    forward_bindings = Map.new(reverse_bindings, &{elem(&1, 1), elem(&1, 0)})
-
-    {forward_bindings, reverse_bindings, expression}
-  end
-
-  @spec bind_variable(Expression.t(variable), bindings_map) ::
-          {pos_integer() | Expression.t(variable), bindings_map}
-        when variable: term(),
-             bindings_map: %{required(:current) => pos_integer(), variable => pos_integer()}
-  defp bind_variable(expr, bindings)
-
-  defp bind_variable(value, %{current: current} = bindings) when Expression.is_variable(value) do
-    case Map.fetch(bindings, value) do
-      :error ->
-        {current, bindings |> Map.update!(:current, &(&1 + 1)) |> Map.put(value, current)}
-
-      {:ok, binding} ->
-        {binding, bindings}
-    end
-  end
-
-  defp bind_variable(expr, bindings) when not is_boolean(expr) do
-    {expr, bindings}
-  end
-
-  @spec lift_clauses(expression :: Expression.cnf_conjunction(literal())) :: cnf()
-  defp lift_clauses(expression)
-  defp lift_clauses(b(left and right)), do: lift_clauses(left) ++ lift_clauses(right)
-
-  defp lift_clauses(b(left or right)),
-    do: [flatten_or_literals(left) ++ flatten_or_literals(right)]
-
-  defp lift_clauses(b(not value)), do: [[-value]]
-  defp lift_clauses(value), do: [[value]]
-
-  @spec flatten_or_literals(expression :: Expression.cnf_clause(literal())) :: [literal()]
-  defp flatten_or_literals(b(left or right)),
-    do: flatten_or_literals(left) ++ flatten_or_literals(right)
-
-  defp flatten_or_literals(b(not value)), do: [-value]
-  defp flatten_or_literals(value), do: [value]
 end

--- a/lib/crux/formula.ex
+++ b/lib/crux/formula.ex
@@ -11,6 +11,7 @@ defmodule Crux.Formula do
   import Crux.Expression, only: [b: 1]
 
   alias Crux.Expression
+  alias Crux.Formula.Tseitin
 
   @typedoc """
   A satisfiability formula in Conjunctive Normal Form (CNF) along with
@@ -173,7 +174,7 @@ defmodule Crux.Formula do
           bindings: bindings,
           reverse_bindings: reverse_bindings,
           auxiliaries: auxiliaries
-        } = Crux.Formula.Tseitin.transform(expression)
+        } = Tseitin.transform(expression)
 
         %__MODULE__{
           cnf: cnf,

--- a/lib/crux/formula/tseitin.ex
+++ b/lib/crux/formula/tseitin.ex
@@ -25,35 +25,21 @@ defmodule Crux.Formula.Tseitin do
   alias Crux.Expression
   alias Crux.Formula
 
-  @typedoc """
-  Output of the Tseitin transformation.
-
-  * `:cnf` — every clause: the root assertion plus all auxiliary
-    definition clauses.
-  * `:definitions` — only the auxiliary definition clauses. Consumers
-    that want to negate the formula (for implication tests) must keep
-    these clauses required; auxiliaries are not freely assignable.
-  * `:bindings` / `:reverse_bindings` — only the user-supplied
-    variables, never auxiliaries.
-  * `:auxiliaries` — the set of integer ids that name auxiliary
-    variables.
-  """
-  @type result(variable) :: %{
-          cnf: Formula.cnf(),
-          definitions: [Formula.clause()],
-          bindings: Formula.bindings(variable),
-          reverse_bindings: Formula.reverse_bindings(variable),
-          auxiliaries: MapSet.t(pos_integer())
-        }
-
   @doc """
   Tseitin-encodes `expression` into CNF.
 
   Assumes `expression` is neither the literal `true` nor `false` —
   callers should short-circuit those at a higher level. Booleans nested
   inside the expression are handled.
+
+  The returned `Formula` separates the auxiliary definition clauses
+  (`:definitions`) from the full CNF (`:cnf`). Consumers that want to
+  negate the formula (for implication tests) must keep the definition
+  clauses required; auxiliaries are not freely assignable. `:bindings`
+  and `:reverse_bindings` only cover user-supplied variables, never
+  auxiliaries; the auxiliary ids live in `:auxiliaries`.
   """
-  @spec transform(Expression.t(variable)) :: result(variable) when variable: term()
+  @spec transform(Expression.t(variable)) :: Formula.t(variable) when variable: term()
   def transform(expression) do
     state = %{
       bindings: %{},
@@ -69,7 +55,7 @@ defmodule Crux.Formula.Tseitin do
     definitions = Enum.reverse(state.definitions)
     cnf = [assertion | definitions]
 
-    %{
+    %Formula{
       cnf: cnf,
       definitions: definitions,
       bindings: state.bindings,

--- a/lib/crux/formula/tseitin.ex
+++ b/lib/crux/formula/tseitin.ex
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2025 crux contributors <https://github.com/ash-project/crux/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Crux.Formula.Tseitin do
+  @moduledoc """
+  Tseitin transformation from a boolean `Crux.Expression` into CNF.
+
+  The naive distributive-law CNF conversion can blow up exponentially
+  (`(a₁ AND b₁) OR ... OR (aₙ AND bₙ)` produces 2ⁿ clauses). Tseitin
+  introduces a fresh auxiliary variable for each compound subexpression
+  and emits clauses that bind the auxiliary to the subexpression's truth
+  value. The resulting CNF grows linearly in the size of the expression
+  at the cost of those auxiliary variables.
+
+  The transformation preserves satisfiability and — because the encoding
+  is the full biconditional (`x ↔ subexpr`) — every user-variable
+  assignment uniquely determines the auxiliary variables, so the set of
+  satisfying user-variable models is identical to the original
+  expression's.
+  """
+
+  import Crux.Expression, only: [b: 1]
+
+  alias Crux.Expression
+  alias Crux.Formula
+
+  @typedoc """
+  Output of the Tseitin transformation.
+
+  * `:cnf` — every clause: the root assertion plus all auxiliary
+    definition clauses.
+  * `:definitions` — only the auxiliary definition clauses. Consumers
+    that want to negate the formula (for implication tests) must keep
+    these clauses required; auxiliaries are not freely assignable.
+  * `:bindings` / `:reverse_bindings` — only the user-supplied
+    variables, never auxiliaries.
+  * `:auxiliaries` — the set of integer ids that name auxiliary
+    variables.
+  """
+  @type result(variable) :: %{
+          cnf: Formula.cnf(),
+          definitions: [Formula.clause()],
+          bindings: Formula.bindings(variable),
+          reverse_bindings: Formula.reverse_bindings(variable),
+          auxiliaries: MapSet.t(pos_integer())
+        }
+
+  @doc """
+  Tseitin-encodes `expression` into CNF.
+
+  Assumes `expression` is neither the literal `true` nor `false` —
+  callers should short-circuit those at a higher level. Booleans nested
+  inside the expression are handled.
+  """
+  @spec transform(Expression.t(variable)) :: result(variable) when variable: term()
+  def transform(expression) do
+    state = %{
+      bindings: %{},
+      reverse_bindings: %{},
+      auxiliaries: MapSet.new(),
+      definitions: [],
+      next_id: 1
+    }
+
+    {root_lit, state} = encode(expression, state)
+
+    assertion = [root_lit]
+    definitions = Enum.reverse(state.definitions)
+    cnf = [assertion | definitions]
+
+    %{
+      cnf: cnf,
+      definitions: definitions,
+      bindings: state.bindings,
+      reverse_bindings: state.reverse_bindings,
+      auxiliaries: state.auxiliaries
+    }
+  end
+
+  @spec encode(Expression.t(variable), map()) :: {Formula.literal(), map()} when variable: term()
+  defp encode(true, state) do
+    {aux, state} = fresh_aux(state)
+    {aux, add_definitions(state, [[aux]])}
+  end
+
+  defp encode(false, state) do
+    {aux, state} = fresh_aux(state)
+    {aux, add_definitions(state, [[-aux]])}
+  end
+
+  defp encode(b(not subexpr), state) do
+    {sub_lit, state} = encode(subexpr, state)
+    {-sub_lit, state}
+  end
+
+  defp encode(b(left and right), state) do
+    {left_lit, state} = encode(left, state)
+    {right_lit, state} = encode(right, state)
+    {aux, state} = fresh_aux(state)
+
+    # aux ↔ (left AND right)
+    new_clauses = [
+      [-aux, left_lit],
+      [-aux, right_lit],
+      [-left_lit, -right_lit, aux]
+    ]
+
+    {aux, add_definitions(state, new_clauses)}
+  end
+
+  defp encode(b(left or right), state) do
+    {left_lit, state} = encode(left, state)
+    {right_lit, state} = encode(right, state)
+    {aux, state} = fresh_aux(state)
+
+    # aux ↔ (left OR right)
+    new_clauses = [
+      [-aux, left_lit, right_lit],
+      [-left_lit, aux],
+      [-right_lit, aux]
+    ]
+
+    {aux, add_definitions(state, new_clauses)}
+  end
+
+  defp encode(variable, state) do
+    case Map.fetch(state.reverse_bindings, variable) do
+      {:ok, id} ->
+        {id, state}
+
+      :error ->
+        {id, state} = next_id(state)
+
+        state = %{
+          state
+          | bindings: Map.put(state.bindings, id, variable),
+            reverse_bindings: Map.put(state.reverse_bindings, variable, id)
+        }
+
+        {id, state}
+    end
+  end
+
+  @spec next_id(map()) :: {pos_integer(), map()}
+  defp next_id(state) do
+    id = state.next_id
+    {id, %{state | next_id: id + 1}}
+  end
+
+  @spec fresh_aux(map()) :: {pos_integer(), map()}
+  defp fresh_aux(state) do
+    {id, state} = next_id(state)
+    {id, %{state | auxiliaries: MapSet.put(state.auxiliaries, id)}}
+  end
+
+  @spec add_definitions(map(), [Formula.clause()]) :: map()
+  defp add_definitions(state, clauses) do
+    %{state | definitions: Enum.reverse(clauses, state.definitions)}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule Crux.MixProject do
       start_permanent: Mix.env() == :prod,
       package: package(),
       deps: deps(),
+      aliases: aliases(),
       docs: &docs/0,
       description: @description,
       source_url: "https://github.com/ash-project/crux",
@@ -61,11 +62,17 @@ defmodule Crux.MixProject do
     ]
   end
 
+  defp aliases do
+    [
+      credo: "credo --strict"
+    ]
+  end
+
   defp deps do
     # styler:sort
     [
       {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false},
-      {:decimal, "~> 3.0", only: [:dev, :test], override: true},
+      {:decimal, "~> 3.1", only: [:dev, :test], override: true},
       {:dialyxir, ">= 0.0.0", only: [:dev, :test], runtime: false},
       {:doctest_formatter, "~> 0.4.1", only: [:dev, :test], runtime: false},
       {:doctor, "~> 0.22.0", only: [:dev, :test], runtime: false},

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,6 @@ defmodule Crux.MixProject do
       start_permanent: Mix.env() == :prod,
       package: package(),
       deps: deps(),
-      aliases: aliases(),
       docs: &docs/0,
       description: @description,
       source_url: "https://github.com/ash-project/crux",
@@ -59,12 +58,6 @@ defmodule Crux.MixProject do
         "Forum" => "https://elixirforum.com/c/elixir-framework-forums/ash-framework-forum",
         "REUSE Compliance" => "https://api.reuse.software/info/github.com/ash-project/crux"
       }
-    ]
-  end
-
-  defp aliases do
-    [
-      credo: "credo --strict"
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
   "credo": {:hex, :credo, "1.7.18", "5c5596bf7aedf9c8c227f13272ac499fe8eae6237bd326f2f07dfc173786f042", [:mix], [{:bunt, "~> 0.2.1 or ~> 1.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "a189d164685fd945809e862fe76a7420c4398fa288d76257662aecb909d6b3e5"},
-  "decimal": {:hex, :decimal, "2.4.1", "6c0fbede12fb122ba685e9ab41c6a40c129e322b3aa192f9e072e61f3a6ffaf2", [:mix], [], "hexpm", "7e618897933a8455f19a727d7c5e50a2c071a544b700e5e724298ecb4340187f"},
+  "decimal": {:hex, :decimal, "3.1.0", "9ede268cff827e6f0c4fb1b34747c82630dce5d7b877dfb22ec8f0cb25855fce", [:mix], [], "hexpm", "e8b3efb3bb3a13cb5e4268ffe128569067b1972e9dee013537c71a5b073168f9"},
   "dialyxir": {:hex, :dialyxir, "1.4.7", "dda948fcee52962e4b6c5b4b16b2d8fa7d50d8645bbae8b8685c3f9ecb7f5f4d", [:mix], [{:erlex, ">= 0.2.8", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "b34527202e6eb8cee198efec110996c25c5898f43a4094df157f8d28f27d9efe"},
   "doctest_formatter": {:hex, :doctest_formatter, "0.4.1", "c69bf93853d1ec5785cbd22dcf0c2bd4dd357cc53f2e89d05850eed7e985462a", [:mix], [], "hexpm", "c1b07495a524126de133be4e077b28c4a2d8e1a14c9eeca962482e2067b5b068"},
   "doctor": {:hex, :doctor, "0.22.0", "223e1cace1f16a38eda4113a5c435fa9b10d804aa72d3d9f9a71c471cc958fe7", [:mix], [{:decimal, "~> 2.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm", "96e22cf8c0df2e9777dc55ebaa5798329b9028889c4023fed3305688d902cd5b"},

--- a/test/crux/formula_test.exs
+++ b/test/crux/formula_test.exs
@@ -157,7 +157,8 @@ defmodule Crux.FormulaTest do
       [_header | body_lines] = String.split(result, "\n")
       assert length(body_lines) == length(formula.cnf)
 
-      Enum.zip(body_lines, formula.cnf)
+      body_lines
+      |> Enum.zip(formula.cnf)
       |> Enum.each(fn {line, clause} ->
         assert line == Enum.join(clause, " ") <> " 0"
       end)

--- a/test/crux/formula_test.exs
+++ b/test/crux/formula_test.exs
@@ -14,51 +14,69 @@ defmodule Crux.FormulaTest do
   doctest Formula
 
   describe inspect(&Formula.from_expression/1) do
-    test "converts an expression to a formula with bindings" do
+    test "converts an expression to a formula with user-only bindings" do
       expression = b((:a and not :b) or (not :c and :d))
 
-      # (:a and not :b) or (not :c and :d) in CNF becomes:
-      # (:a or not :c) and (:a or :d) and (not :b or not :c) and (not :b or :d)
-      result = Formula.from_expression(expression)
+      formula = Formula.from_expression(expression)
 
-      assert %Formula{
-               cnf: [
-                 # :a or :d
-                 [1, 2],
-                 # not :b or :d
-                 [-3, 2],
-                 # :a or not :c
-                 [1, -4],
-                 # not :b or not :c
-                 [-3, -4]
-               ],
-               bindings: %{
-                 1 => :a,
-                 2 => :d,
-                 3 => :b,
-                 4 => :c
-               }
-             } = result
+      # Bindings hold only user variables — auxiliary Tseitin ids are
+      # tracked separately and never leak into bindings.
+      assert formula.bindings |> Map.values() |> Enum.sort() == [:a, :b, :c, :d]
+      assert MapSet.size(formula.auxiliaries) > 0
+
+      assert formula.bindings
+             |> Map.keys()
+             |> Enum.all?(&(not MapSet.member?(formula.auxiliaries, &1)))
+
+      # The encoded CNF is satisfiability-equivalent to the source.
+      assert Crux.satisfying_scenarios(formula) ==
+               Crux.satisfying_scenarios(%Formula{
+                 cnf: [[1, 2], [-3, 2], [1, -4], [-3, -4]],
+                 bindings: %{1 => :a, 2 => :d, 3 => :b, 4 => :c},
+                 reverse_bindings: %{a: 1, d: 2, b: 3, c: 4}
+               })
+    end
+
+    test "stays linear on the historical exponential-blowup pattern (issue #23)" do
+      # `(n_i AND e_i) OR ...` would distribute to 2^pairs clauses under
+      # the naive CNF conversion; Tseitin keeps it ~6×pairs.
+      pairs = 30
+
+      expression =
+        Enum.reduce(1..pairs, false, fn i, acc ->
+          {:or, acc, {:and, String.to_atom("n#{i}"), String.to_atom("e#{i}")}}
+        end)
+
+      {time_us, formula} = :timer.tc(fn -> Formula.from_expression(expression) end)
+
+      assert length(formula.cnf) < 10 * pairs
+      assert time_us < 100_000
+      assert Crux.satisfiable?(formula)
     end
 
     test "converts simple expressions" do
-      # Single variable
+      # Single variable — no compound subexpression to encode, so no aux.
       result = Formula.from_expression(b(:a))
-      assert %Formula{cnf: [[1]], bindings: %{1 => :a}} = result
+      assert %Formula{cnf: [[1]], bindings: %{1 => :a}, auxiliaries: aux} = result
+      assert MapSet.size(aux) == 0
 
-      # Single negated variable
+      # Single negated variable — `not` is encoded inline, also no aux.
       result = Formula.from_expression(b(not :a))
-      assert %Formula{cnf: [[-1]], bindings: %{1 => :a}} = result
+      assert %Formula{cnf: [[-1]], bindings: %{1 => :a}, auxiliaries: aux} = result
+      assert MapSet.size(aux) == 0
 
-      # Simple OR
+      # Simple OR — `:a or :b` simplifies to a single literal at the
+      # root, so still no aux for trivial disjunction.
       result = Formula.from_expression(b(:a or :b))
-      assert %Formula{cnf: [[1, 2]], bindings: %{1 => :a, 2 => :b}} = result
+      assert %Formula{bindings: %{1 => :a, 2 => :b}} = result
 
-      # Simple AND
+      # Simple AND now goes through Tseitin and gains an auxiliary
+      # representing the conjunction.
       result = Formula.from_expression(b(:a and :b))
-      assert %Formula{cnf: [[1], [2]], bindings: %{1 => :a, 2 => :b}} = result
+      assert %Formula{bindings: %{1 => :a, 2 => :b}, auxiliaries: aux} = result
+      assert MapSet.size(aux) >= 1
 
-      # Booleans
+      # Booleans short-circuit to constants.
       assert %Formula{cnf: [], bindings: %{}} = Formula.from_expression(true)
       assert %Formula{cnf: [[1], [-1]], bindings: %{}} = Formula.from_expression(false)
     end
@@ -115,34 +133,34 @@ defmodule Crux.FormulaTest do
   end
 
   describe inspect(&Formula.to_picosat/1) do
-    test "converts a formula to DIMACS format" do
-      # Simple conjunction: :a and :b
-      expression = b(:a and :b)
-      formula = Formula.from_expression(expression)
-      result = Formula.to_picosat(formula)
+    test "single literal expressions match DIMACS exactly" do
+      # Trivial inputs that don't introduce Tseitin auxiliaries.
+      assert Formula.to_picosat(Formula.from_expression(b(:a))) ==
+               "p cnf 1 1\n1 0"
 
-      # Should produce CNF with 2 variables and 2 clauses
-      assert result == "p cnf 2 2\n1 0\n2 0"
+      assert Formula.to_picosat(Formula.from_expression(b(not :a))) ==
+               "p cnf 1 1\n-1 0"
     end
 
-    test "converts more complex formulas" do
-      # Disjunction: :a or :b
-      expression = b(:a or :b)
-      formula = Formula.from_expression(expression)
+    test "the DIMACS header counts user + auxiliary variables" do
+      formula = Formula.from_expression(b(:a and :b))
       result = Formula.to_picosat(formula)
 
-      # Should produce CNF with 2 variables and 1 clause
-      assert result == "p cnf 2 1\n1 2 0"
+      expected_vars = map_size(formula.bindings) + MapSet.size(formula.auxiliaries)
+      assert result =~ ~r/^p cnf #{expected_vars} #{length(formula.cnf)}\n/
     end
 
-    test "handles negated variables" do
-      # Not :a
-      expression = b(not :a)
-      formula = Formula.from_expression(expression)
+    test "every clause is rendered as space-separated literals terminated by 0" do
+      formula = Formula.from_expression(b((:a and :b) or :c))
       result = Formula.to_picosat(formula)
 
-      # Should produce CNF with 1 variable and 1 clause
-      assert result == "p cnf 1 1\n-1 0"
+      [_header | body_lines] = String.split(result, "\n")
+      assert length(body_lines) == length(formula.cnf)
+
+      Enum.zip(body_lines, formula.cnf)
+      |> Enum.each(fn {line, clause} ->
+        assert line == Enum.join(clause, " ") <> " 0"
+      end)
     end
   end
 end

--- a/test/crux_test.exs
+++ b/test/crux_test.exs
@@ -27,11 +27,10 @@ defmodule CruxTest do
 
       assert {:ok, result} = Crux.solve(formula)
 
-      assert result in [
-               %{a: true},
-               %{b: true},
-               %{a: true, b: true}
-             ]
+      # Any assignment over {:a, :b} that makes (:a or :b) true is valid.
+      defaults = %{a: false, b: false}
+      assignment = Map.merge(defaults, result)
+      assert assignment.a or assignment.b
     end
 
     test "returns :unsatisfiable for an unsatisfiable formula" do


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Tseytin_transformation

Applying DeMorgan's law leads to exponential blowup in certan patterns of boolean expressions. Tseitin transformation introduces new variables that map to more complex statements such that the expression grows linearly instead of exponentially.

fixes #23