### PR TITLE
fix: `DistributivityBasedSimplificationLaw` doesn't reach a fixpoint

### DIFF
--- a/lib/crux/expression/rewrite_rule/distributivity_based_simplification_law.ex
+++ b/lib/crux/expression/rewrite_rule/distributivity_based_simplification_law.ex
@@ -17,13 +17,22 @@ defmodule Crux.Expression.RewriteRule.DistributivityBasedSimplificationLaw do
   These patterns use distributivity properties to eliminate redundant terms
   involving complements, simplifying expressions by removing parts that
   don't affect the overall result.
+
+  A rewrite splices `right` in beside the retained term, which can produce a
+  fresh match at the same node, so the rule needs reapplication to reach a
+  fixpoint.
   """
 
   use Crux.Expression.RewriteRule
 
   import Crux.Expression, only: [b: 1]
 
-  @impl Crux.Expression.RewriteRule
+  alias Crux.Expression.RewriteRule
+
+  @impl RewriteRule
+  def needs_reapplication?, do: true
+
+  @impl RewriteRule
   def walk(b(expr and (not expr or right))), do: b(expr and right)
   def walk(b(expr or (not expr and right))), do: b(expr or right)
   def walk(b(not expr and (expr or right))), do: b(not expr and right)

--- a/test/crux/expression/rewrite_rule/distributivity_based_simplification_law_test.exs
+++ b/test/crux/expression/rewrite_rule/distributivity_based_simplification_law_test.exs
@@ -9,6 +9,7 @@ defmodule Crux.Expression.RewriteRule.DistributivityBasedSimplificationLawTest d
   import Crux.Expression, only: [b: 1]
 
   alias Crux.Expression
+  alias Crux.Expression.RewriteRule
   alias Crux.Expression.RewriteRule.DistributivityBasedSimplificationLaw
 
   doctest DistributivityBasedSimplificationLaw, import: true
@@ -205,12 +206,27 @@ defmodule Crux.Expression.RewriteRule.DistributivityBasedSimplificationLawTest d
       result = Expression.postwalk(expr, &DistributivityBasedSimplificationLaw.walk/1)
       assert result == b(:a or (:b or :c))
     end
+
+    test "reaches a fixpoint when a rewrite re-triggers its own pattern" do
+      exprs_and_expected = [
+        {b(:a and (not :a or (not :a or :b))), b(:a and :b)},
+        {b(:a or (not :a and (not :a and :b))), b(:a or :b)},
+        {b(not :a and (:a or (:a or :b))), b(not :a and :b)},
+        {b(not :a or (:a and (:a and :b))), b(not :a or :b)}
+      ]
+
+      for {expr, expected} <- exprs_and_expected do
+        {result, _acc_map} = RewriteRule.apply(expr, [DistributivityBasedSimplificationLaw])
+        assert result == expected
+      end
+    end
   end
 
-  property "applying distributivity-based simplification law is idempotent" do
+  property "applying distributivity-based simplification law is idempotent after stabilization" do
     check all(expr <- Expression.generate_expression(StreamData.atom(:alphanumeric))) do
-      result1 = Expression.postwalk(expr, &DistributivityBasedSimplificationLaw.walk/1)
-      result2 = Expression.postwalk(result1, &DistributivityBasedSimplificationLaw.walk/1)
+      {result1, _acc_map1} = RewriteRule.apply(expr, [DistributivityBasedSimplificationLaw])
+      {result2, _acc_map2} = RewriteRule.apply(result1, [DistributivityBasedSimplificationLaw])
+
       assert result1 == result2
     end
   end


### PR DESCRIPTION
Closes #38.

## The bug

`DistributivityBasedSimplificationLaw` rewrites `NOT A OR (A AND B)` to `NOT A OR B` by splicing
`B` in beside the retained term. When `B` is itself `A AND B'`, the rewritten node matches the
same clause again — but `postwalk/2` never revisits a node it has just rewritten, and the child
node (`A AND (A AND B')`) matches none of the four patterns on its own, so nothing collapses it
on the way up.

Because the rule declared `needs_reapplication?` as `false`, `RewriteRule.apply/2` stopped one
step short of the fixpoint:

```elixir
iex> {result, _} = RewriteRule.apply(b(not :a or (:a and (:a and :b))), [Law])
iex> result
{:or, {:not, :a}, {:and, :a, :b}}   # still reducible to `not :a or :b`
```

All four clauses are affected:

| Input | Before | Fixpoint |
|---|---|---|
| `:a and (not :a or (not :a or :b))` | `:a and (not :a or :b)` | `:a and :b` |
| `:a or (not :a and (not :a and :b))` | `:a or (not :a and :b)` | `:a or :b` |
| `not :a and (:a or (:a or :b))` | `not :a and (:a or :b)` | `not :a and :b` |
| `not :a or (:a and (:a and :b))` | `not :a or (:a and :b)` | `not :a or :b` |

Results were always logically equivalent — the defect is missed simplification, not a wrong
answer.

## The fix

Declare `needs_reapplication?, do: true` so `apply/2` iterates to a fixpoint. This matches
`UnitResolution`, which shares two of these four patterns verbatim and already declares it;
`DeMorgansLaw` and `DistributiveLaw` do the same. Termination is guaranteed because every
rewrite strictly shrinks the term.

The idempotency property now goes through `apply/2`, the same shape the other reapplying rules
use. It still catches the bug — reverting the rule change alone makes it fail.

Making `walk/1` recurse on its own output would also work, but it duplicates the fixpoint
machinery `needs_reapplication?/0` exists to provide, and would leave `UnitResolution`
inconsistent with it.

## Scope

- `Expression.simplify/1` was **not** affected. All eleven of its rules chunk together and
  `UnitResolution` already forces the chunk to be reapplied to a fixpoint — which is why this
  went unnoticed.
- `Expression.expand/2,3` **was** affected: `simplify_one_expression/1` calls each rule's
  `walk/1` exactly once per node with no fixpoint loop.
- `RewriteRule.apply(expr, [DistributivityBasedSimplificationLaw])` in isolation **was**
  affected, as above.

## Verification

- `mix check --no-retry` passes.
- Verified against `stream_data` 1.4.0 locally, including seed 614272 — the seed that failed on
  #34. `mix.lock` is deliberately left at 1.3.0 here so this stays a source-only change; #34
  should go green once this lands.
- The bug reproduces on `stream_data` 1.3.0 too, so the bump didn't introduce it. 1.4.0 shrinks
  `one_of/1` towards earlier elements, which changed the generated stream enough for the property
  to finally find a witness.
